### PR TITLE
17 merchant invoice show page invoice item information

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -40,14 +40,26 @@
   margin: 10px;
 }
 
-#inv_cust_info {
-  display :flex;
-  flex-direction: row;
-  justify-content: flex-start;
+#merchant_invoice_items {
+  margin: auto;
+  width: calc(100% - 20px);
+  border-collapse: collapse;
 }
 
-#inv_cust_info div {
-  padding-right: 5px;
+#merchant_invoice_items th {
+  background-color: darkgray;
+  color: white;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  border: 1px solid black;
+}
+
+#merchant_invoice_items td {
+  background-color: lightgray;
+  text-align: center;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  border: 1px solid black;
 }
 
 .invoice_links {

--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -1,12 +1,13 @@
 class MerchantInvoicesController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
-    @invoices = @merchant.invoices
+    @invoices = @merchant.distinct_invoices
   end
 
   def show
     @merchant = Merchant.find(params[:merchant_id])
     @invoice = Invoice.find(params[:id])
     @customer = @invoice.customer
+    @invoice_items = @invoice.merchant_items(@merchant)
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,3 +1,5 @@
+
+
 class Invoice < ApplicationRecord
 
   belongs_to :customer
@@ -7,9 +9,10 @@ class Invoice < ApplicationRecord
   enum status: [:in_progress, :completed, :cancelled]
 
   def merchant_items(merchant)
-    items
-      .where(merchant: merchant)
-      .select('items.name, invoice_items.*')
+    invoice_items
+      .joins(:item)
+      .select('invoice_items.*, items.name, items.merchant_id')
+      .where('items.merchant_id = ?', merchant.id)
   end
 
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -6,4 +6,10 @@ class Invoice < ApplicationRecord
 
   enum status: [:in_progress, :completed, :cancelled]
 
+  def merchant_items(merchant)
+    items
+      .where(merchant: merchant)
+      .select('items.name, invoice_items.*')
+  end
+
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,4 +1,7 @@
+require_relative 'priceable'
+
 class InvoiceItem < ApplicationRecord
+  include Priceable
 
   belongs_to :invoice
   belongs_to :item

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,11 +1,9 @@
+require_relative 'priceable'
+
 class Item < ApplicationRecord
+  include Priceable
   belongs_to :merchant
 
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
-
-  def price_convert
-    dollars = unit_price.to_f/100
-    '%.2f' % dollars
-  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,9 +1,10 @@
 class Merchant < ApplicationRecord
 
   has_many :items
+  has_many :invoices, through: :items
 
-  def invoices
-    Invoice.joins(:items).where("items.merchant_id = #{id}").distinct
+  def distinct_invoices
+    invoices.distinct
   end
 
 end

--- a/app/models/priceable.rb
+++ b/app/models/priceable.rb
@@ -1,0 +1,6 @@
+module Priceable
+  def price_convert
+    dollars = unit_price.to_f/100
+    '%.2f' % dollars
+  end
+end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -3,8 +3,22 @@
 <div id="inv_info_container">
   <div class="inv_info"><strong>Status:</strong> <%= @invoice.status.gsub("_", " ").titleize %></div>
   <div class="inv_info"><strong>Created On:</strong> <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></div>
-  <div class="inv_info" id="inv_cust_info">
-    <div><strong>Customer:</strong></div>
-    <div><%= "#{@customer.first_name} #{@customer.last_name}" %></div>
-  </div>
+  <div class="inv_info"><strong>Customer:</strong> <%= "#{@customer.first_name} #{@customer.last_name}" %></div>
+  <div class="inv_info"><strong>Items on this Invoice:</strong></div>
+  <table id="merchant_invoice_items">
+    <tr>
+      <th>Item Name</th>
+      <th>Quantity</th>
+      <th>Unit Price</th>
+      <th>Status</th>
+    </tr>
+    <% @invoice_items.each do |invoice_item| %>
+      <tr id="invoice_item_<%= invoice_item.id %>">
+        <td><%= invoice_item.name %></td>
+        <td><%= invoice_item.quantity %></td>
+        <td>$<%= invoice_item.price_convert %></td>
+        <td><%= invoice_item.status.titleize %></td>
+      </tr>
+    <% end %>
+  </table>
 </div>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   factory :invoice_item do
     item
     invoice
-    qantity {rand(1..500)}
+    quantity {rand(1..500)}
     unit_price { rand(100..15000) }
     status { rand(3) }
   end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
     @invoice_2.items << [@item_3, @item_4]
     @invoice_3.items << [@item_1, @item_4]
     @invoice_4.items << @item_2
+
+    @invoice_1.invoice_items.each do |invoice_item|
+      invoice_item.update!(status: :pending)
+    end
   end
 
   it 'lists the invoices that contain an item sold by the merchant' do
@@ -35,7 +39,7 @@ RSpec.describe 'Merchant Invoices Index Page', type: :feature do
     within("li#invoice_#{@invoice_1.id}") do
       expect(page).to have_link("#{@invoice_1.id}")
       click_link("#{@invoice_1.id}")
-      expect(current_path).to eq("/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}")
+      expect(current_path).to eq(merchant_invoice_path(@merchant_1.id, @invoice_1.id))
     end
   end
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -5,8 +5,15 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
   before(:each) do
     @merchant_1 = create(:merchant)
     @item_1 = create(:item, merchant: @merchant_1)
-    @invoice_1 = create(:invoice, status: 0)
-    @invoice_1.items << @item_1
+    @item_2 = create(:item, merchant: @merchant_1)
+
+    @merchant_2 = create(:merchant)
+    @item_3 = create(:item, merchant: @merchant_2)
+
+    @invoice_1 = create(:invoice, status: :in_progress)
+    @inv_item_1 = create(:invoice_item, invoice: @invoice_1, item: @item_1)
+    @inv_item_2 = create(:invoice_item, invoice: @invoice_1, item: @item_2)
+    @inv_item_3 = create(:invoice_item, invoice: @invoice_1, item: @item_3)
 
     visit merchant_invoice_path(@merchant_1.id, @invoice_1.id)
   end
@@ -21,7 +28,25 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
 
   it 'shows the customer name' do
     customer = @invoice_1.customer
-    expect(page).to have_content("Customer:\n#{customer.first_name} #{customer.last_name}")
+    expect(page).to have_content("Customer: #{customer.first_name} #{customer.last_name}")
+  end
+
+  it 'has a list of the merchants items on the invoice' do
+    within("tr#invoice_item_#{@inv_item_1.id}") do
+      expect(page).to have_content(@item_1.name)
+      expect(page).to have_content(@inv_item_1.quantity)
+      expect(page).to have_content("$#{@inv_item_1.price_convert}")
+      expect(page).to have_content(@inv_item_1.status.titleize)
+    end
+    within("tr#invoice_item_#{@inv_item_2.id}") do
+      expect(page).to have_content(@item_2.name)
+      expect(page).to have_content(@inv_item_2.quantity)
+      expect(page).to have_content("$#{@inv_item_2.price_convert}")
+      expect(page).to have_content(@inv_item_2.status.titleize)
+    end
+
+    expect(page).to_not have_content(@item_3.name)
+    expect(page).to_not have_content(@inv_item_3.quantity)
   end
 
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -21,4 +21,44 @@ RSpec.describe Invoice, type: :model do
       expect(invoice.in_progress?).to be(false)
     end
   end
+
+  describe 'instance methods' do
+
+    before(:each) do
+      @merchant_1 = create(:merchant)
+      @item_1 = create(:item, merchant: @merchant_1, unit_price: 1500, name: 'Pencil')
+      @item_2 = create(:item, merchant: @merchant_1)
+
+      @merchant_2 = create(:merchant)
+      @item_3 = create(:item, merchant: @merchant_2, name: 'Art', unit_price: 10000)
+      @item_4 = create(:item, merchant: @merchant_2)
+      @item_5 = create(:item, merchant: @merchant_2, name: 'Coaster', unit_price: 500)
+
+      @invoice_1 = create(:invoice)
+
+      @inv_item_1 = create(:invoice_item, invoice: @invoice_1, item: @item_1, quantity: 375, unit_price: 1450)
+      @inv_item_2 = create(:invoice_item, invoice: @invoice_1, item: @item_3, quantity: 5, unit_price: 9950)
+      @inv_item_3 = create(:invoice_item, invoice: @invoice_1, item: @item_5, quantity: 10, unit_price: 450)
+    end
+
+    describe '.merchant_items' do
+      it 'returns a list of items on an invoice belonging to a merchant. includes item name and information from invoice_item' do
+        merchant_1_items = @invoice_1.merchant_items(@merchant_1)
+
+        expect(merchant_1_items.length).to eq(1)
+        expect(merchant_1_items.pluck(:name)).to eq(["Pencil"])
+        expect(merchant_1_items.pluck(:quantity)).to eq([375])
+        expect(merchant_1_items.pluck(:unit_price)).to eq([1450])
+
+        merchant_2_items = @invoice_1.merchant_items(@merchant_2)
+
+        expect(merchant_2_items.length).to eq(2)
+        expect(merchant_2_items.pluck(:name)).to eq(["Art", "Coaster"])
+        expect(merchant_2_items.pluck(:quantity)).to eq([5, 10])
+        expect(merchant_2_items.pluck(:unit_price)).to eq([9950, 450])
+      end
+    end
+
+  end
 end
+

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Merchant, type: :model do
 
       describe '.invoices' do
         it 'returns a list of invoices which contain an item from the merchant' do
-          expect(@merchant_1.invoices).to eq([@invoice_1, @invoice_3, @invoice_4])
-          expect(@merchant_2.invoices).to eq([@invoice_1, @invoice_2, @invoice_3])
+          expect(@merchant_1.distinct_invoices).to eq([@invoice_1, @invoice_3, @invoice_4])
+          expect(@merchant_2.distinct_invoices).to eq([@invoice_1, @invoice_2, @invoice_3])
         end
       end
     end


### PR DESCRIPTION
1. Updated the merchant model to use a has_many association with invoices.
2. Added method to the invoice model which returns a list of invoice items for a particular merchant.
3. Added a table to the merchant invoice show page that lists the invoice items and relevant information.

Merchant Invoice Show Page: Invoice Item Information

As a merchant
When I visit my merchant invoice show page
Then I see all of my items on the invoice including:
- Item name
- The quantity of the item ordered
- The price the Item sold for
- The Invoice Item status
And I do not see any information related to Items for other merchants

