### PR TITLE
11 merchant items grouped by status

### DIFF
--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -2,7 +2,7 @@
 <h2 class="subtitle">My Items</h2>
 
 <section id="enabled">
-<h3>Enabled</h3>
+<h3>Enabled Items</h3>
 <ul>
   <% @items.each do |item| %>
     <% if item.status == true %>
@@ -17,7 +17,7 @@
 </section>
 
 <section id="disabled">
-<h3>Disabled</h3>
+<h3>Disabled Items</h3>
 <ul>
   <% @items.each do |item| %> 
     <% if item.status == false %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,6 +1,8 @@
 <%= render partial: '/merchants/merchants-nav', locals: {merchant: @merchant} %>
 <h2 class="subtitle">My Items</h2>
 
+<section id="enabled">
+<h3>Enabled</h3>
 <ul>
   <% @items.each do |item| %>
     <% if item.status == true %>
@@ -9,12 +11,21 @@
               <%= button_to "Disable", merchant_item_path(@merchant.id, item.id), method: :patch, params:[status: false]%>
         </li></p>
       </div>
-    <% else %>
-      <div id="item_<%= item.id %>">
-      <p><li><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %>
-             <%= button_to "Enable", merchant_item_path(@merchant.id, item.id), method: :patch, params:[status: true]%>
-      </li></p>
-      </div>
     <% end %>
   <% end %>
+  </ul>
+</section>
+
+<section id="disabled">
+<h3>Disabled</h3>
+    <% @items.each do |item| %> 
+      <% if item.status == false %>
+        <div id="item_<%= item.id %>">
+        <p><li><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %>
+              <%= button_to "Enable", merchant_item_path(@merchant.id, item.id), method: :patch, params:[status: true]%>
+        </li></p>
+        </div>
+      <% end %>
+    <% end %>
 </ul>
+</section>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -13,19 +13,20 @@
       </div>
     <% end %>
   <% end %>
-  </ul>
+</ul>
 </section>
 
 <section id="disabled">
 <h3>Disabled</h3>
-    <% @items.each do |item| %> 
-      <% if item.status == false %>
-        <div id="item_<%= item.id %>">
-        <p><li><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %>
-              <%= button_to "Enable", merchant_item_path(@merchant.id, item.id), method: :patch, params:[status: true]%>
-        </li></p>
-        </div>
-      <% end %>
+<ul>
+  <% @items.each do |item| %> 
+    <% if item.status == false %>
+      <div id="item_<%= item.id %>">
+      <p><li><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %>
+            <%= button_to "Enable", merchant_item_path(@merchant.id, item.id), method: :patch, params:[status: true]%>
+      </li></p>
+      </div>
     <% end %>
+  <% end %>
 </ul>
 </section>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe 'Merchant Items Index Page: ' do
             end
           end
         end
+
         it 'items are listed in appropriate sections' do
           visit merchant_items_path(@merch1.id)
 
@@ -108,7 +109,7 @@ RSpec.describe 'Merchant Items Index Page: ' do
           end
 
           within("#enabled") do
-            within("#item_#{@item1.id}") dgit o
+            within("#item_#{@item1.id}") do
               click_button 'Disable'
             end
           end
@@ -124,7 +125,7 @@ RSpec.describe 'Merchant Items Index Page: ' do
           within("#disabled") do
             within("#item_#{@item1.id}") do
               expect(page).to have_link(@item1.name)
-              expect(page).to have_button("Disable")
+              expect(page).to have_button("Enable")
             end
           end
         end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -87,6 +87,48 @@ RSpec.describe 'Merchant Items Index Page: ' do
           expect(page).to have_button('Enable')
         end
       end
+
+      describe 'I see two sections, Enabled and Disabled' do
+        it 'has Enabled and Disabled sections' do
+          visit merchant_items_path(@merch1.id)
+
+          within("#enabled") do
+            within("#item_#{@item1.id}") do
+              expect(page).to have_link(@item1.name)
+              expect(page).to have_button("Disable")
+            end
+          end
+        end
+        it 'items are listed in appropriate sections' do
+          visit merchant_items_path(@merch1.id)
+
+          within("#enabled") do
+            expect(page).to have_link(@item1.name)
+            expect(page).to have_link(@item2.name)
+          end
+
+          within("#enabled") do
+            within("#item_#{@item1.id}") dgit o
+              click_button 'Disable'
+            end
+          end
+
+          within("#enabled") do
+            expect(page).to_not have_link(@item1.name)
+            within("#item_#{@item2.id}") do
+              expect(page).to have_link(@item2.name)
+              expect(page).to have_button("Disable")
+            end
+          end
+  
+          within("#disabled") do
+            within("#item_#{@item1.id}") do
+              expect(page).to have_link(@item1.name)
+              expect(page).to have_button("Disable")
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When I visit my merchant items index page
Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
And I see that each Item is listed in the appropriate section