### PR TITLE
19 merchant invoice show page update item status

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,9 +14,17 @@
  *= require_self
  */
 
-#page_title {
-  text-align: center;
+body {
+  font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
 }
+#page_title {
+  color: black;
+  text-align: center;
+  font-weight: 900;
+  font-size: 3rem;
+  text-shadow: 1px 1px 0px gray, 2px 2px 0px darkgray, 5px 5px 3px lightgray;
+}
+
 
 #merchants_nav {
   display: flex;
@@ -82,15 +90,45 @@
 }
 
 .nav_button {
-  padding: 5px;
-  border: 1px solid black;
+  padding: 10px;
+  border-radius: 20px;
+  border: 1px solid white;
   margin-left: 2px;
+  transition: all 0.5s;
+}
+
+.nav_button:hover {
+  padding: 10px;
+  border-radius: 20px;
+  border: 1px solid lightgray;
+  margin-left: 2px;
+  background-color: lightgray;
+}
+
+.list_item {
+  display: flex;
+  flex-direction: row;
+}
+
+.item_link {
+  padding-right: 15px;
+}
+
+a:visited {
+  color: blue;
+}
+
+#merchants_nav a {
+  text-decoration: none;
+  color: inherit;
 }
 
 .selected_nav_button {
-  padding: 5px;
+  padding: 10px;
+  border-radius: 20px;
   margin-left: 2px;
-  border: 2px solid black;
+  background-color: lightgray;
+  border: 1px solid lightgray;
 }
 
 .subtitle {

--- a/app/controllers/invoice_items_controller.rb
+++ b/app/controllers/invoice_items_controller.rb
@@ -1,0 +1,14 @@
+class InvoiceItemsController < ApplicationController
+  def update
+    @invoice_item = InvoiceItem.find(params[:id])
+    @invoice_item.update(invoice_item_params)
+    flash[:success] = "#{@invoice_item.item.name} status successfully updated."
+    redirect_to merchant_invoice_path(@invoice_item.merchant.id, @invoice_item.invoice.id)
+  end
+
+  private
+
+  def invoice_item_params
+    params.require(:invoice_item).permit(:status)
+  end
+end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -5,6 +5,7 @@ class InvoiceItem < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :item
+  has_one :merchant, through: :item
 
   enum status: [:pending, :packaged, :shipped]
 

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -17,7 +17,12 @@
         <td><%= invoice_item.name %></td>
         <td><%= invoice_item.quantity %></td>
         <td>$<%= invoice_item.price_convert %></td>
-        <td><%= invoice_item.status.titleize %></td>
+        <td>
+          <%= form_with model: invoice_item, local: true do |f| %>
+            <%= f.select :status, [["Pending", :pending], ["Packaged", :packaged], ["Shipped", :shipped]] %>
+            <%= f.submit "Update Status" %>
+          <% end %>   
+        </td>
       </tr>
     <% end %>
   </table>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -7,7 +7,7 @@
   <% @items.each do |item| %>
     <% if item.status == true %>
       <div id="item_<%= item.id %>">
-        <p><li><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %>
+        <p><li class="list_item"><span class="item_link"><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %></span>
               <%= button_to "Disable", merchant_item_path(@merchant.id, item.id), method: :patch, params:[status: false]%>
         </li></p>
       </div>
@@ -21,8 +21,8 @@
 <ul>
   <% @items.each do |item| %> 
     <% if item.status == false %>
-      <div id="item_<%= item.id %>">
-      <p><li><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %>
+      <div  id="item_<%= item.id %>">
+      <p><li class="list_item"><span class="item_link"><%= link_to "#{item.name}", merchant_item_path(@merchant.id, item.id) %></span>
             <%= button_to "Enable", merchant_item_path(@merchant.id, item.id), method: :patch, params:[status: true]%>
       </li></p>
       </div>

--- a/app/views/merchants/_merchants-nav.html.erb
+++ b/app/views/merchants/_merchants-nav.html.erb
@@ -4,19 +4,25 @@
     <% if current_page?(merchant_dashboard_path(merchant.id)) %>
       <li class="selected_nav_button">Dashboard</li>
     <% else %>
-      <li class="nav_button"><%= link_to 'Dashboard', merchant_dashboard_path(merchant.id) %></li>
+      <%= link_to merchant_dashboard_path(merchant.id) do %>
+        <li class="nav_button">Dashboard</li>
+      <% end %>
     <% end %>
 
     <% if current_page?(merchant_items_path(merchant.id)) %>
       <li class="selected_nav_button">My Items</li>
     <% else %>
-      <li class="nav_button"><%= link_to 'My Items', merchant_items_path(merchant.id)  %></li>
+      <%= link_to merchant_items_path(merchant.id) do %>
+        <li class="nav_button">My Items</li>
+      <% end %>
     <% end %>
     
     <% if current_page?(merchant_invoices_path(merchant.id)) %>
       <li class="selected_nav_button">My Invoices</li>
     <% else %>
-      <li class="nav_button"><%= link_to 'My Invoices', merchant_invoices_path(merchant.id)  %></li>  
+      <%= link_to merchant_invoices_path(merchant.id) do %>
+        <li class="nav_button">My Invoices</li>
+      <% end %>  
     <% end %>
   </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
     resources :items, controller: :merchant_items, only: [:index, :show, :edit, :update]
     resources :invoices, controller: :merchant_invoices, only: [:index, :show]
   end
+  
+  resources :invoice_items, only: [:update]
 
   namespace :admin do
     get '/', to: 'dashboard#index'

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
     @item_3 = create(:item, merchant: @merchant_2)
 
     @invoice_1 = create(:invoice, status: :in_progress)
-    @inv_item_1 = create(:invoice_item, invoice: @invoice_1, item: @item_1)
-    @inv_item_2 = create(:invoice_item, invoice: @invoice_1, item: @item_2)
+    @inv_item_1 = create(:invoice_item, invoice: @invoice_1, item: @item_1, status: :packaged)
+    @inv_item_2 = create(:invoice_item, invoice: @invoice_1, item: @item_2, status: :packaged)
     @inv_item_3 = create(:invoice_item, invoice: @invoice_1, item: @item_3)
 
     visit merchant_invoice_path(@merchant_1.id, @invoice_1.id)
@@ -47,6 +47,23 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
 
     expect(page).to_not have_content(@item_3.name)
     expect(page).to_not have_content(@inv_item_3.quantity)
+  end
+
+  it 'each invoice item has status dropdown with update button' do
+    within("tr#invoice_item_#{@inv_item_1.id}") do
+      select "Shipped", from: "invoice_item_status"
+      click_button "Update Status"
+      
+      expect(current_path).to eq(merchant_invoice_path(@merchant_1.id, @invoice_1.id))
+      expect(@inv_item_1.reload.status).to eq("shipped")
+    end
+    within("tr#invoice_item_#{@inv_item_2.id}") do
+      select "Pending", from: "invoice_item_status"
+      click_button "Update Status"
+      
+      expect(current_path).to eq(merchant_invoice_path(@merchant_1.id, @invoice_1.id))
+      expect(@inv_item_2.reload.status).to eq("pending")
+    end
   end
 
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Merchant, type: :model do
 
       describe '.invoices' do
         it 'returns a list of invoices which contain an item from the merchant' do
-          expect(@merchant_1.distinct_invoices).to eq([@invoice_1, @invoice_3, @invoice_4])
-          expect(@merchant_2.distinct_invoices).to eq([@invoice_1, @invoice_2, @invoice_3])
+          expect(@merchant_1.distinct_invoices).to match_array([@invoice_1, @invoice_3, @invoice_4])
+          expect(@merchant_2.distinct_invoices).to match_array([@invoice_1, @invoice_2, @invoice_3])
         end
       end
     end


### PR DESCRIPTION
As a merchant
When I visit my merchant invoice show page
I see that each invoice item status is a select field
And I see that the invoice item's current status is selected
When I click this select field,
Then I can select a new status for the Item,
And next to the select field I see a button to "Update Item Status"
When I click this button
I am taken back to the merchant invoice show page
And I see that my Item's status has now been updated