### PR TITLE
feat: merchant dashboard page with merchant name

### DIFF
--- a/app/controllers/merchant_dashboard_controller.rb
+++ b/app/controllers/merchant_dashboard_controller.rb
@@ -1,0 +1,5 @@
+class MerchantDashboardController < ApplicationController
+  def index
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+end

--- a/app/views/merchant_dashboard/index.html.erb
+++ b/app/views/merchant_dashboard/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: '/merchants/merchants-nav', locals: {merchant: @merchant} %>

--- a/app/views/merchants/_merchants-nav.html.erb
+++ b/app/views/merchants/_merchants-nav.html.erb
@@ -1,10 +1,10 @@
 <div id="merchants_nav">
   <span id="merchant_name">Merchant: <%= merchant.name %></span>
   <ul id="nav_buttons">
-    <% if current_page?(merchant_dashboard_path(merchant.id)) %>
+    <% if current_page?(merchant_dashboard_index_path(merchant.id)) %>
       <li class="selected_nav_button">Dashboard</li>
     <% else %>
-      <%= link_to merchant_dashboard_path(merchant.id) do %>
+      <%= link_to merchant_dashboard_index_path(merchant.id) do %>
         <li class="nav_button">Dashboard</li>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  get '/merchants/:id/dashboard', to: 'merchants#dashboard', as: :merchant_dashboard
-
   resources :merchants, except: [:index, :new, :edit, :update, :destroy] do
+    resources :dashboard, controller: :merchant_dashboard, only: [:index]
     resources :items, controller: :merchant_items, only: [:index, :show, :edit, :update, :new, :create]
     resources :invoices, controller: :merchant_invoices, only: [:index, :show]
   end

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Dashboard Index' do
+  before :each do
+    @merchant = create(:merchant)
+    visit merchant_dashboard_index_path(@merchant.id)
+  end
+
+  it 'lists the merchant name' do
+    expect(page).to have_content(@merchant.name)
+  end
+end


### PR DESCRIPTION
As a merchant,
When I visit my merchant dashboard (/merchants/merchant_id/dashboard)
Then I see the name of my merchant