### PR TITLE
added tests for links on dashboard page

### DIFF
--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -9,4 +9,20 @@ RSpec.describe 'Merchant Dashboard Index' do
   it 'lists the merchant name' do
     expect(page).to have_content(@merchant.name)
   end
+
+  it 'has a link to merchant items index' do
+    expect(page).to have_link("My Items")
+
+    click_link("My Items")
+
+    expect(current_path).to eq(merchant_items_path(@merchant.id))
+  end
+
+  it 'has a link to merchant invoices index' do
+    expect(page).to have_link("My Invoices")
+
+    click_link("My Invoices")
+    
+    expect(current_path).to eq(merchant_invoices_path(@merchant.id))
+  end
 end


### PR DESCRIPTION
Links were already there from last pull request but added tests for them.

As a merchant,
When I visit my merchant dashboard
Then I see link to my merchant items index (/merchants/merchant_id/items)
And I see a link to my merchant invoices index (/merchants/merchant_id/invoices)