### PR TITLE
6 merchant dashboard invoices sorted by least recent

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -15,7 +15,7 @@ class InvoiceItem < ApplicationRecord
   end
 
   def invoice_date
-    invoice.create_at
+    invoice.created_at
   end
 
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -14,4 +14,8 @@ class InvoiceItem < ApplicationRecord
     item.name
   end
 
+  def invoice_date
+    invoice.create_at
+  end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -9,7 +9,10 @@ class Merchant < ApplicationRecord
   end
 
   def inv_items_ready_to_ship
-    invoice_items.where(status: [:pending, :packaged])
+    invoice_items
+      .joins(:invoice)
+      .where(status: [:pending, :packaged])
+      .order('invoices.created_at asc')
   end
 
   def top_five_customers

--- a/app/views/merchant_dashboard/index.html.erb
+++ b/app/views/merchant_dashboard/index.html.erb
@@ -5,7 +5,7 @@
     <ul id="items_ready_list">
       <% @invoice_items_ready_to_ship.each do |invoice_item| %>
         <li class="item_ready" id="item_ready_<%= invoice_item.id %>">
-          <%= invoice_item.item_name %> - Invoice #<%= link_to invoice_item.invoice_id, merchant_invoice_path(@merchant.id, invoice_item.invoice_id) %>
+          <%= invoice_item.item_name %> - Invoice #<%= link_to invoice_item.invoice_id, merchant_invoice_path(@merchant.id, invoice_item.invoice_id) %> - <%= invoice_item.invoice_date.strftime("%A, %B %-d, %Y") %>
         </li>
       <% end %>
     </ul>

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -84,29 +84,34 @@ RSpec.describe 'Merchant Dashboard Index' do
     end
   end
 
-  it 'lists invoice items ready to ship with a link to the invoice show page' do
-    merchant = create(:merchant)
-    items = create_list(:item, 6, merchant: merchant)
-    invoices = create_list(:invoice, 2)
-    inv_item_1 = create(:invoice_item, item: items[0], invoice: invoices[0], status: :packaged)
-    inv_item_2 = create(:invoice_item, item: items[4], invoice: invoices[0], status: :pending)
-    inv_item_3 = create(:invoice_item, item: items[3], invoice: invoices[0], status: :shipped)
-    inv_item_4 = create(:invoice_item, item: items[1], invoice: invoices[0], status: :packaged)
-    inv_item_5 = create(:invoice_item, item: items[2], invoice: invoices[0], status: :shipped)
-    inv_item_5 = create(:invoice_item, item: items[5], invoice: invoices[1], status: :pending)
+  describe 'Items Ready to Ship' do
+    before :each do
+      @merchant = create(:merchant)
+      @items = create_list(:item, 6, merchant: @merchant)
+      @invoices = create_list(:invoice, 2)
+      @inv_item_1 = create(:invoice_item, item: @items[0], invoice: @invoices[0], status: :packaged)
+      @inv_item_2 = create(:invoice_item, item: @items[4], invoice: @invoices[0], status: :pending)
+      @inv_item_3 = create(:invoice_item, item: @items[3], invoice: @invoices[0], status: :shipped)
+      @inv_item_4 = create(:invoice_item, item: @items[1], invoice: @invoices[0], status: :packaged)
+      @inv_item_5 = create(:invoice_item, item: @items[2], invoice: @invoices[0], status: :shipped)
+      @inv_item_5 = create(:invoice_item, item: @items[5], invoice: @invoices[1], status: :pending)
+    end
 
-    expect(page).to have_content("Items Ready to Ship")
-    
-    merchant.inv_items_ready_to_ship.each do |inv_item|
-      visit(merchant_dashboard_index_path(merchant.id))
-      within ("li#item_ready_#{inv_item.id}")  do
-        expect(page).to have_content("#{inv_item.item_name} - Invoice ##{inv_item.invoice_id}")
-        expect(page).to have_link("#{inv_item.invoice_id}")
-
-        click_link("#{inv_item.invoice_id}")
-
-        expect(current_path).to eq(merchant_invoice_path(merchant.id, inv_item.invoice_id))
+    it 'lists invoice items ready to ship with a link to the invoice show page and the date the invoice was created' do
+      expect(page).to have_content("Items Ready to Ship")
+      
+      @merchant.inv_items_ready_to_ship.each do |inv_item|
+        visit(merchant_dashboard_index_path(@merchant.id))
+        within ("li#item_ready_#{inv_item.id}")  do
+          expect(page).to have_content("#{inv_item.item_name} - Invoice ##{inv_item.invoice_id} - #{inv_item.invoice_date.strftime("%A, %B %-d, %Y")}")
+          expect(page).to have_link("#{inv_item.invoice_id}")
+  
+          click_link("#{inv_item.invoice_id}")
+  
+          expect(current_path).to eq(merchant_invoice_path(@merchant.id, inv_item.invoice_id))
+        end
       end
     end
+
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe InvoiceItem, type: :model do
 
         expect(invoice_item.item_name).to eq(invoice_item.item.name)
       end
+
+      it 'returns the date thats its invoice was created' do
+        invoice_item = create(:invoice_item)
+
+        expect(invoice_item.invoice_date).to eq(invoice_item.invoice.created_at)
+      end
     end
   end
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -210,6 +210,7 @@ RSpec.describe Merchant, type: :model do
       expect(@merch2.top_five_revenue).to eq([@item3, @item8, @item5, @item7, @item6])
     end
   end
+
 describe 'to see if it helps' do
     it '.top_five_merchants' do
      merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
@@ -280,18 +281,30 @@ describe 'to see if it helps' do
    end
 
   describe '.inv_items_ready_to_ship' do
-    it 'returns a list of invoice items that are not yet shipped' do
-      merchant = create(:merchant)
-      items = create_list(:item, 6, merchant: merchant)
-      invoices = create_list(:invoice, 2)
-      inv_item_1 = create(:invoice_item, item: items[0], invoice: invoices[0], status: :packaged)
-      inv_item_2 = create(:invoice_item, item: items[4], invoice: invoices[0], status: :pending)
-      inv_item_3 = create(:invoice_item, item: items[3], invoice: invoices[0], status: :shipped)
-      inv_item_4 = create(:invoice_item, item: items[1], invoice: invoices[0], status: :packaged)
-      inv_item_5 = create(:invoice_item, item: items[2], invoice: invoices[0], status: :shipped)
-      inv_item_5 = create(:invoice_item, item: items[5], invoice: invoices[1], status: :pending)
 
-      expect(merchant.inv_items_ready_to_ship).to match_array([inv_item_1, inv_item_2, inv_item_4, inv_item_5])
+    before :each do
+      @merchant = create(:merchant)
+      @items = create_list(:item, 6, merchant: @merchant)
+
+      @invoice_1 = create(:invoice, created_at: '2012-03-25 09:54:09 UTC')
+      @invoice_2 = create(:invoice, created_at: '2012-03-26 09:54:09 UTC')
+      @invoice_3 = create(:invoice, created_at: '2012-03-27 09:54:09 UTC')
+      @invoice_4 = create(:invoice, created_at: '2012-03-28 09:54:09 UTC')
+      
+      @inv_item_1 = create(:invoice_item, item: @items[0], invoice: @invoice_3, status: :packaged)
+      @inv_item_2 = create(:invoice_item, item: @items[4], invoice: @invoice_4, status: :pending)
+      @inv_item_3 = create(:invoice_item, item: @items[3], invoice: @invoice_1, status: :shipped)
+      @inv_item_4 = create(:invoice_item, item: @items[1], invoice: @invoice_1, status: :packaged)
+      @inv_item_5 = create(:invoice_item, item: @items[2], invoice: @invoice_1, status: :shipped)
+      @inv_item_5 = create(:invoice_item, item: @items[5], invoice: @invoice_2, status: :pending)
+    end
+
+    it 'returns a list of invoice items that are not yet shipped' do
+      expect(@merchant.inv_items_ready_to_ship).to match_array([@inv_item_1, @inv_item_2, @inv_item_4, @inv_item_5])
+    end
+
+    it 'lists them oldest to newest' do
+      expect(@merchant.inv_items_ready_to_ship).to eq([@inv_item_4, @inv_item_5, @inv_item_1, @inv_item_2])
     end
   end
 end


### PR DESCRIPTION
As a merchant
When I visit my merchant dashboard
In the section for "Items Ready to Ship",
Next to each Item name I see the date that the invoice was created
And I see the date formatted like "Monday, July 18, 2019"
And I see that the list is ordered from oldest to newest